### PR TITLE
Prevent stuck cursor on Chrome

### DIFF
--- a/crowdsorter/templates/vote.html
+++ b/crowdsorter/templates/vote.html
@@ -76,7 +76,11 @@
 {{- super() }}
     <!-- Custom -->
     <script type="text/javascript">
-        $('form').submit( function(){
+        $(document).ready( function () {
+           $('html,body').css('cursor','pointer');
+        });
+
+        $('form').submit( function() {
             $('#vote-a').prop('disabled', true);
             $('#vote-b').prop('disabled', true);
             $('#reload').prop('disabled', true);


### PR DESCRIPTION
Chrome seems to keep the previous cursor state until the pointer is moved.